### PR TITLE
Update scan.dart - takePicture() function has no parameters

### DIFF
--- a/example/lib/scan.dart
+++ b/example/lib/scan.dart
@@ -151,7 +151,7 @@ class _ScanState extends State<Scan> {
     }
 
     try {
-      await controller.takePicture(filePath);
+      await controller.takePicture();
     } on CameraException catch (e) {
       log(e.toString());
       return null;


### PR DESCRIPTION
Seems like takePicutre from CameraController does not take a parameter:

````
  /// Captures an image and returns the file where it was saved.
  ///
  /// Throws a [CameraException] if the capture fails.
  Future<XFile> takePicture() async {
    _throwIfNotInitialized("takePicture");
    if (value.isTakingPicture) {
      throw CameraException(
        'Previous capture has not returned yet.',
        'takePicture was called before the previous capture returned.',
      );
    }
    try {
      value = value.copyWith(isTakingPicture: true);
      XFile file = await CameraPlatform.instance.takePicture(_cameraId);
      value = value.copyWith(isTakingPicture: false);
      return file;
    } on PlatformException catch (e) {
      value = value.copyWith(isTakingPicture: false);
      throw CameraException(e.code, e.message);
    }
  }
````